### PR TITLE
Rdb applied join 02

### DIFF
--- a/rdb/applied_join/08.sql
+++ b/rdb/applied_join/08.sql
@@ -1,0 +1,6 @@
+-- 姓がエマヌエーレである上司を持つ従業員の一覧を取得する
+SELECT * FROM employees
+	WHERE boss_id IN (
+		SELECT id FROM employees
+			WHERE second_name = 'エマヌエーレ'
+		);

--- a/rdb/applied_join/08_create_table.sql
+++ b/rdb/applied_join/08_create_table.sql
@@ -1,15 +1,15 @@
 -- 上司のIDを振ったカラムを追加し、自分自身を上司にすることを禁止
 ALTER TABLE employees
-	ADD COLUMN boss_id INTEGER REFERENCES employees(id),
-	ADD CONSTRAINT boss_id CHECK(boss_id != id);
+	ADD COLUMN boss_id INTEGER REFERENCES employees(id)
+	,ADD CONSTRAINT boss_id CHECK(boss_id != id);
 
 -- 姓名をカラムに追加
 ALTER TABLE employees
-	ADD COLUMN first_name TEXT,
-	ADD COLUMN second_name TEXT;
+	ADD COLUMN first_name TEXT
+	,ADD COLUMN second_name TEXT;
 
 -- 姓名入力後に姓名のNULL値を禁止し、nameカラムを削除
 ALTER TABLE employees
-	ALTER COLUMN first_name SET NOT NULL,
-	ALTER COLUMN second_name SET NOT NULL,
-	DROP COLUMN name;
+	ALTER COLUMN first_name SET NOT NULL
+	,ALTER COLUMN second_name SET NOT NULL
+	,DROP COLUMN name;

--- a/rdb/applied_join/08_create_table.sql
+++ b/rdb/applied_join/08_create_table.sql
@@ -1,0 +1,15 @@
+-- 上司のIDを振ったカラムを追加し、自分自身を上司にすることを禁止
+ALTER TABLE employees
+	ADD COLUMN boss_id INTEGER REFERENCES employees(id),
+	ADD CONSTRAINT boss_id CHECK(boss_id != id);
+
+-- 姓名をカラムに追加
+ALTER TABLE employees
+	ADD COLUMN first_name TEXT,
+	ADD COLUMN second_name TEXT;
+
+-- 姓名入力後に姓名のNULL値を禁止し、nameカラムを削除
+ALTER TABLE employees
+	ALTER COLUMN first_name SET NOT NULL,
+	ALTER COLUMN second_name SET NOT NULL,
+	DROP COLUMN name;


### PR DESCRIPTION
・テーブル構成の理由
従業員と上司というのは1:nの関係であるため、従業員と上司の関係性についてのテーブルを別で作成する意味はないと考えた。
上司が退職した場合などに生じる更新異状については別のテーブルを作成することでも防げないため、同じ従業員テーブル内で上司の従業員IDを参照する形とした。